### PR TITLE
feat(series): add move portfolios functionality between series

### DIFF
--- a/apps/backend/cmd/api/main.go
+++ b/apps/backend/cmd/api/main.go
@@ -342,6 +342,7 @@ func main() {
 	adminRoutes.Post("/series", capMiddleware.RequireCapability("series"), adminHandler.CreateSeries)
 	adminRoutes.Patch("/series/:id", capMiddleware.RequireCapability("series"), adminHandler.UpdateSeries)
 	adminRoutes.Delete("/series/:id", capMiddleware.RequireCapability("series"), adminHandler.DeleteSeries)
+	adminRoutes.Post("/series/:id/move-portfolios", capMiddleware.RequireCapability("series"), adminHandler.MovePortfoliosSeries)
 	adminRoutes.Get("/series/:id/export/preview", capMiddleware.RequireCapability("series"), adminHandler.GetSeriesExportPreview)
 	adminRoutes.Get("/series/:id/export", capMiddleware.RequireCapability("series"), adminHandler.GetSeriesExportData)
 

--- a/apps/backend/internal/dto/admin.go
+++ b/apps/backend/internal/dto/admin.go
@@ -192,6 +192,10 @@ type AdminUpdatePortfolioRequest struct {
 	TagIDs []uuid.UUID `json:"tag_ids,omitempty"`
 }
 
+type MovePortfoliosSeriesRequest struct {
+	TargetSeriesID *uuid.UUID `json:"target_series_id"` // null = hapus assignment (set ke NULL)
+}
+
 // Dashboard Stats
 type DashboardStatsDTO struct {
 	Users                   UserStatsDTO                `json:"users"`

--- a/apps/backend/internal/handler/admin_handler.go
+++ b/apps/backend/internal/handler/admin_handler.go
@@ -718,6 +718,44 @@ func (h *AdminHandler) DeleteSeries(c *fiber.Ctx) error {
 	return c.JSON(dto.SuccessResponse(nil, "Series berhasil dihapus"))
 }
 
+func (h *AdminHandler) MovePortfoliosSeries(c *fiber.Ctx) error {
+	sourceID, err := uuid.Parse(c.Params("id"))
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(dto.ErrorResponse("VALIDATION_ERROR", "ID series sumber tidak valid"))
+	}
+
+	// Verify source series exists
+	_, err = h.adminRepo.FindSeriesByID(sourceID)
+	if err != nil {
+		return c.Status(fiber.StatusNotFound).JSON(dto.ErrorResponse("NOT_FOUND", "Series sumber tidak ditemukan"))
+	}
+
+	var req dto.MovePortfoliosSeriesRequest
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(dto.ErrorResponse("VALIDATION_ERROR", "Request body tidak valid"))
+	}
+
+	// Verify target series exists (if not null)
+	if req.TargetSeriesID != nil {
+		if *req.TargetSeriesID == sourceID {
+			return c.Status(fiber.StatusBadRequest).JSON(dto.ErrorResponse("VALIDATION_ERROR", "Series tujuan tidak boleh sama dengan series sumber"))
+		}
+		_, err = h.adminRepo.FindSeriesByID(*req.TargetSeriesID)
+		if err != nil {
+			return c.Status(fiber.StatusNotFound).JSON(dto.ErrorResponse("NOT_FOUND", "Series tujuan tidak ditemukan"))
+		}
+	}
+
+	rowsAffected, err := h.adminRepo.MovePortfoliosToSeries(sourceID, req.TargetSeriesID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(dto.ErrorResponse("INTERNAL_ERROR", "Gagal memindahkan portfolio"))
+	}
+
+	return c.JSON(dto.SuccessResponse(fiber.Map{
+		"moved_count": rowsAffected,
+	}, "Portfolio berhasil dipindahkan"))
+}
+
 // User Management Handlers
 func (h *AdminHandler) ListUsers(c *fiber.Ctx) error {
 	search := c.Query("search")

--- a/apps/backend/internal/repository/admin_repository.go
+++ b/apps/backend/internal/repository/admin_repository.go
@@ -301,6 +301,14 @@ func (r *AdminRepository) GetSeriesPortfolioCount(id uuid.UUID) (int64, error) {
 	return count, err
 }
 
+// MovePortfoliosToSeries moves all portfolios from one series to another (or NULL)
+func (r *AdminRepository) MovePortfoliosToSeries(sourceSeriesID uuid.UUID, targetSeriesID *uuid.UUID) (int64, error) {
+	result := r.db.Model(&domain.Portfolio{}).
+		Where("series_id = ? AND deleted_at IS NULL", sourceSeriesID).
+		Update("series_id", targetSeriesID)
+	return result.RowsAffected, result.Error
+}
+
 // UpdateSeriesBlocks replaces all blocks for a series
 func (r *AdminRepository) UpdateSeriesBlocks(seriesID uuid.UUID, blocks []domain.SeriesBlock) error {
 	return r.db.Transaction(func(tx *gorm.DB) error {

--- a/apps/web/app/admin/(dashboard)/moderation/page.tsx
+++ b/apps/web/app/admin/(dashboard)/moderation/page.tsx
@@ -336,7 +336,7 @@ export default function ModerationPage() {
                 <DialogTitle className="line-clamp-1 text-lg font-semibold">
                   {selectedPortfolio?.judul}
                 </DialogTitle>
-                <DialogDescription className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
                   <div className="flex items-center gap-1.5">
                     <Avatar className="h-5 w-5">
                       <AvatarImage src={selectedPortfolio?.user?.avatar_url} />
@@ -367,7 +367,7 @@ export default function ModerationPage() {
                       </span>
                     </>
                   )}
-                </DialogDescription>
+                </div>
               </div>
             </div>
 

--- a/apps/web/app/admin/(dashboard)/series/page.tsx
+++ b/apps/web/app/admin/(dashboard)/series/page.tsx
@@ -19,6 +19,7 @@ import {
   ChevronUp,
   FileDown,
   Search,
+  ArrowRightLeft,
 } from 'lucide-react';
 import { getDebugEmptyState } from '@/lib/utils/debug';
 import { DebugBanner } from '@/components/admin/debug-banner';
@@ -84,6 +85,7 @@ export default function AdminSeriesPage() {
   const [deleteSeries, setDeleteSeries] = useState<Series | null>(null);
   const [previewSeriesId, setPreviewSeriesId] = useState<string | null>(null);
   const [exportSeries, setExportSeries] = useState<Series | null>(null);
+  const [moveSeries, setMoveSeries] = useState<Series | null>(null);
 
   const { data, isLoading } = useQuery({
     queryKey: ['admin-series', searchQuery],
@@ -210,6 +212,17 @@ export default function AdminSeriesPage() {
             size="sm"
             onClick={(e) => {
               e.stopPropagation();
+              setMoveSeries(s);
+            }}
+          >
+            <ArrowRightLeft className="h-4 w-4 mr-1" />
+            Ganti Series
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
               setExportSeries(s);
             }}
           >
@@ -327,6 +340,13 @@ export default function AdminSeriesPage() {
         series={exportSeries}
         open={!!exportSeries}
         onClose={() => setExportSeries(null)}
+      />
+
+      <MovePortfoliosDialog
+        sourceSeries={moveSeries}
+        allSeries={series}
+        open={!!moveSeries}
+        onClose={() => setMoveSeries(null)}
       />
     </div>
   );
@@ -763,6 +783,162 @@ function SeriesPreviewDialog({
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>
             Tutup
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function MovePortfoliosDialog({
+  sourceSeries,
+  allSeries,
+  open,
+  onClose,
+}: {
+  sourceSeries: Series | null;
+  allSeries: Series[];
+  open: boolean;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [targetSeriesId, setTargetSeriesId] = useState<string | null>(null);
+  const [step, setStep] = useState<'select' | 'confirm'>('select');
+
+  const moveMutation = useMutation({
+    mutationFn: () => adminSeriesApi.movePortfoliosSeries(sourceSeries!.id, targetSeriesId),
+    onSuccess: (data) => {
+      const movedCount = data?.data?.moved_count || 0;
+      const targetName = targetSeriesId
+        ? allSeries.find((s) => s.id === targetSeriesId)?.nama || 'series tujuan'
+        : 'Tanpa Series';
+      toast.success(`${movedCount} portfolio berhasil dipindahkan ke "${targetName}"`);
+      queryClient.invalidateQueries({ queryKey: ['admin-series'] });
+      handleClose();
+    },
+    onError: () => {
+      toast.error('Gagal memindahkan portfolio');
+    },
+  });
+
+  const handleClose = () => {
+    setTargetSeriesId(null);
+    setStep('select');
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    if (step === 'select') {
+      setStep('confirm');
+    } else {
+      moveMutation.mutate();
+    }
+  };
+
+  const targetSeriesOptions = allSeries.filter((s) => s.id !== sourceSeries?.id);
+  const selectedTargetName = targetSeriesId
+    ? allSeries.find((s) => s.id === targetSeriesId)?.nama
+    : null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ArrowRightLeft className="h-5 w-5" />
+            {step === 'select' ? 'Ganti Series' : 'Konfirmasi'}
+          </DialogTitle>
+          {step === 'select' ? (
+            <div className="text-muted-foreground text-sm">
+              Pindahkan semua portfolio dari series{' '}
+              <strong className="text-foreground">&quot;{sourceSeries?.nama}&quot;</strong>{' '}
+              ({sourceSeries?.portfolio_count || 0} portfolio) ke series lain.
+            </div>
+          ) : (
+            <div className="text-muted-foreground text-sm">
+              Apakah Anda yakin ingin memindahkan semua portfolio?
+            </div>
+          )}
+        </DialogHeader>
+
+        {step === 'select' ? (
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label>Series Tujuan</Label>
+              <Select
+                value={targetSeriesId || 'none'}
+                onValueChange={(val) => setTargetSeriesId(val === 'none' ? null : val)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Pilih series tujuan" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">
+                    <span className="text-muted-foreground">Tanpa Series (hapus assignment)</span>
+                  </SelectItem>
+                  <Separator className="my-1" />
+                  {targetSeriesOptions.map((s) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      <div className="flex items-center gap-2">
+                        <span>{s.nama}</span>
+                        {!s.is_active && (
+                          <Badge variant="secondary" className="text-xs">Nonaktif</Badge>
+                        )}
+                        <span className="text-xs text-muted-foreground">
+                          ({s.portfolio_count || 0} portfolio)
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {targetSeriesId === null && (
+              <p className="text-xs text-amber-600 bg-amber-50 dark:bg-amber-950/30 rounded-md p-2">
+                Portfolio akan dihapus dari series ini (series_id menjadi NULL). Portfolio tidak akan terhapus, hanya relasi series-nya saja.
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-3 py-2">
+            <div className="rounded-lg border bg-muted/50 p-4 space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Dari:</span>
+                <span className="font-medium">{sourceSeries?.nama}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Ke:</span>
+                <span className="font-medium">
+                  {targetSeriesId ? selectedTargetName : 'Tanpa Series'}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">Jumlah portfolio:</span>
+                <span className="font-medium">{sourceSeries?.portfolio_count || 0}</span>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Content blocks portfolio tidak akan diubah. Hanya assignment series yang akan dipindahkan.
+            </p>
+          </div>
+        )}
+
+        <DialogFooter>
+          {step === 'confirm' && (
+            <Button variant="outline" onClick={() => setStep('select')}>
+              Kembali
+            </Button>
+          )}
+          <Button variant="outline" onClick={handleClose}>
+            Batal
+          </Button>
+          <Button
+            onClick={handleConfirm}
+            disabled={moveMutation.isPending || (step === 'select' && targetSeriesId === undefined)}
+          >
+            {moveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {step === 'select' ? 'Lanjutkan' : 'Pindahkan'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/app/admin/(dashboard)/series/page.tsx
+++ b/apps/web/app/admin/(dashboard)/series/page.tsx
@@ -802,14 +802,16 @@ function MovePortfoliosDialog({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
-  const [targetSeriesId, setTargetSeriesId] = useState<string | null>(null);
+  const [targetSeriesId, setTargetSeriesId] = useState<string | undefined>(undefined);
   const [step, setStep] = useState<'select' | 'confirm'>('select');
 
   const moveMutation = useMutation({
-    mutationFn: () => adminSeriesApi.movePortfoliosSeries(sourceSeries!.id, targetSeriesId),
+    mutationFn: () => adminSeriesApi.movePortfoliosSeries(sourceSeries!.id, targetSeriesId === 'none' ? null : (targetSeriesId || null)),
     onSuccess: (data) => {
       const movedCount = data?.data?.moved_count || 0;
-      const targetName = targetSeriesId
+      const targetName = targetSeriesId === 'none'
+        ? 'Tanpa Series'
+        : targetSeriesId
         ? allSeries.find((s) => s.id === targetSeriesId)?.nama || 'series tujuan'
         : 'Tanpa Series';
       toast.success(`${movedCount} portfolio berhasil dipindahkan ke "${targetName}"`);
@@ -822,7 +824,7 @@ function MovePortfoliosDialog({
   });
 
   const handleClose = () => {
-    setTargetSeriesId(null);
+    setTargetSeriesId(undefined);
     setStep('select');
     onClose();
   };
@@ -836,7 +838,9 @@ function MovePortfoliosDialog({
   };
 
   const targetSeriesOptions = allSeries.filter((s) => s.id !== sourceSeries?.id);
-  const selectedTargetName = targetSeriesId
+  const selectedTargetName = targetSeriesId === 'none'
+    ? 'Tanpa Series'
+    : targetSeriesId
     ? allSeries.find((s) => s.id === targetSeriesId)?.nama
     : null;
 
@@ -866,13 +870,16 @@ function MovePortfoliosDialog({
             <div className="space-y-2">
               <Label>Series Tujuan</Label>
               <Select
-                value={targetSeriesId || 'none'}
-                onValueChange={(val) => setTargetSeriesId(val === 'none' ? null : val)}
+                value={targetSeriesId}
+                onValueChange={(val) => setTargetSeriesId(val)}
               >
                 <SelectTrigger>
                   <SelectValue placeholder="Pilih series tujuan" />
                 </SelectTrigger>
                 <SelectContent>
+                  <SelectItem value="" disabled>
+                    Pilih series tujuan
+                  </SelectItem>
                   <SelectItem value="none">
                     <span className="text-muted-foreground">Tanpa Series (hapus assignment)</span>
                   </SelectItem>
@@ -894,7 +901,7 @@ function MovePortfoliosDialog({
               </Select>
             </div>
 
-            {targetSeriesId === null && (
+            {targetSeriesId === 'none' && (
               <p className="text-xs text-amber-600 bg-amber-50 dark:bg-amber-950/30 rounded-md p-2">
                 Portfolio akan dihapus dari series ini (series_id menjadi NULL). Portfolio tidak akan terhapus, hanya relasi series-nya saja.
               </p>
@@ -910,7 +917,7 @@ function MovePortfoliosDialog({
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">Ke:</span>
                 <span className="font-medium">
-                  {targetSeriesId ? selectedTargetName : 'Tanpa Series'}
+                  {selectedTargetName || 'Tanpa Series'}
                 </span>
               </div>
               <div className="flex items-center justify-between text-sm">
@@ -935,7 +942,7 @@ function MovePortfoliosDialog({
           </Button>
           <Button
             onClick={handleConfirm}
-            disabled={moveMutation.isPending || (step === 'select' && targetSeriesId === undefined)}
+            disabled={moveMutation.isPending || (step === 'select' && targetSeriesId == null)}
           >
             {moveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {step === 'select' ? 'Lanjutkan' : 'Pindahkan'}

--- a/apps/web/lib/api/admin/index.ts
+++ b/apps/web/lib/api/admin/index.ts
@@ -450,6 +450,14 @@ export const adminSeriesApi = {
     return response.data;
   },
 
+  movePortfoliosSeries: async (sourceSeriesId: string, targetSeriesId: string | null) => {
+    const response = await api.post<ApiResponse<{ moved_count: number }>>(
+      `/admin/series/${sourceSeriesId}/move-portfolios`,
+      { target_series_id: targetSeriesId }
+    );
+    return response.data;
+  },
+
   // Export endpoints
   getExportPreview: async (id: string, params?: { jurusan_id?: string; kelas_id?: string }) => {
     const response = await api.get<ApiResponse<ExportPreviewResponse>>(`/admin/series/${id}/export/preview`, { params });

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -120,7 +120,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -356,7 +355,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -4341,7 +4339,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4352,7 +4349,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4402,7 +4398,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -4908,7 +4903,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5343,7 +5337,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6195,7 +6188,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6381,7 +6373,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8424,7 +8415,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.8.tgz",
       "integrity": "sha512-LmcZzG04JuzNXi48s5P+TnJBsTGPJunViNKV/iE4uM6kstjTQsQhvsAv+xF6MJxU2Pr26tl15eVbp0jQnsv6/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.0.8",
         "@swc/helpers": "0.5.15",
@@ -8944,7 +8934,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8954,7 +8943,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8998,7 +8986,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.68.0.tgz",
       "integrity": "sha512-oNN3fjrZ/Xo40SWlHf1yCjlMK417JxoSJVUXQjGdvdRCU07NTFei1i1f8ApUAts+IVh14e4EdakeLEA+BEAs/Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9972,7 +9959,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10145,7 +10131,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10671,7 +10656,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can bulk-move portfolios from one series to another (or clear series) via a new "Ganti Series" workflow in the admin dashboard, with server-side support and success/error feedback.
* **Refactor**
  * Minor markup adjustment in the moderation preview header to align styling and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->